### PR TITLE
Autobase

### DIFF
--- a/src/org/team1540/robot2017/RobotMap.java
+++ b/src/org/team1540/robot2017/RobotMap.java
@@ -1,5 +1,7 @@
 package org.team1540.robot2017;
 
+import com.ctre.CANTalon;
+
 /**
  * The RobotMap is a mapping from the ports sensors and actuators are wired into
  * to a variable name. This provides flexibility changing wiring, makes checking
@@ -7,29 +9,30 @@ package org.team1540.robot2017;
  * floating around.
  */
 public class RobotMap {
-	public static final int climberTalonTop = 0;
-	public static final int climberTalonBottom = 2;
-	public static final int feederTalonTop = 10;
-	public static final int feederTalonLeft = 4;
-	public static final int feederTalonRight = 6;
-	public static final int gearSliderTalon = 11;
+	
+	public static final int climberTalonTop = 12;
+	public static final int climberTalonBottom = 11;
+	
+	public static final int gearSliderTalon = 3;
 //	public static final int gearServoRightDeploy;
 //	public static final int gearServoLeftDeploy;
-	public static final int intakeTalon = 7;
-	public static final int shooterTalonRightFlywheel = 10;
-	public static final int shooterTalonLeftFlywheel = 11;
-	public static final int shooterTalonBelt = 8;
-//	public static final int driveTalonRightA = 12;
-//	public static final int driveTalonRightB = 13;
-//	public static final int driveTalonRightC = 1;
-//	public static final int driveTalonLeftA = 3;
-//	public static final int driveTalonLeftB = 15;
-//	public static final int driveTalonLeftC = 14;
 	
-	public static final int driveTalonRightA = 1;
-	public static final int driveTalonRightB = 2;
-	public static final int driveTalonRightC = 3;
-	public static final int driveTalonLeftA = 4;
-	public static final int driveTalonLeftB = 5;
-	public static final int driveTalonLeftC = 6;
+	public static final int intakeTalon = 16;
+	
+	public static final int feederTalonTop = 15;
+	public static final int feederTalonRight = 4;
+	public static final int feederTalonLeft = 5;
+	
+	public static final int beltTalon = 2;
+	
+	public static final int shooterTalonRightFlywheel = 10;
+	public static final int shooterTalonLeftFlywheel = 13;
+	
+	public static final int driveTalonRightA = 6;
+	public static final int driveTalonRightB = 9;
+	public static final int driveTalonRightC = 14;
+	public static final int driveTalonLeftA = 1;
+	public static final int driveTalonLeftB = 7;
+	public static final int driveTalonLeftC = 8;
+	
 }

--- a/src/org/team1540/robot2017/commands/AccurateTurn.java
+++ b/src/org/team1540/robot2017/commands/AccurateTurn.java
@@ -11,13 +11,12 @@ public class AccurateTurn extends Command {
 
 	//TODO make these tunable
 	public double calibration = 1;
-	public double p = 0.0;
-	public double i = 0.0;
-	public double d = 0.0;
+	public double p = 0.10;
+	public double i = 0.00;
+	public double d = 0.00;
 	
 	private boolean isFinished = false;
 	
-	public String address = "";
 	private NetworkTable table;
 	private String valueKey;
 	
@@ -25,16 +24,13 @@ public class AccurateTurn extends Command {
 	private CANTalon driveRightTalon = Robot.driveTrain.driveLeftTalon;
 	
 	public AccurateTurn(String tableKey, String valueKey) {
-		NetworkTable.setIPAddress(address);
-		NetworkTable.setClientMode();
 		table = NetworkTable.getTable(tableKey);
 		this.valueKey = valueKey;
+		driveLeftTalon.reverseOutput(true);
+		driveRightTalon.reverseOutput(true);
 	}
 	
 	public AccurateTurn(String tableKey, String valueKey, String address) {
-		this.address = address;
-		NetworkTable.setIPAddress(address);
-		NetworkTable.setClientMode();
 		table = NetworkTable.getTable(tableKey);
 		this.valueKey = valueKey;
 	}
@@ -43,20 +39,31 @@ public class AccurateTurn extends Command {
 	@Override
 	protected void initialize() {
 		Robot.driveTrain.setControlModeAsFollower();
-	}
-
-	// Called repeatedly when this Command is scheduled to run
-	@Override
-	protected void execute() {
+		
 		driveLeftTalon.setP(p);
 		driveLeftTalon.setI(i);
 		driveLeftTalon.setD(d);
 		driveRightTalon.setP(p);
 		driveRightTalon.setI(i);
 		driveRightTalon.setD(d);
+	}
+
+	// Called repeatedly when this Command is scheduled to run
+	@Override
+	protected void execute() {
+		table.putNumber("setpointL", driveLeftTalon.getSetpoint());
+		table.putNumber("setpointR", driveRightTalon.getSetpoint());
+		table.putNumber("positionL", driveLeftTalon.getEncPosition());
+		table.putNumber("positionR", driveRightTalon.getEncPosition());
+		table.putNumber("errorL", driveLeftTalon.getError());
+		table.putNumber("errorR", driveRightTalon.getError());
 		
-		driveLeftTalon.setSetpoint(table.getNumber(valueKey,0)*calibration);
-		driveLeftTalon.setSetpoint(-table.getNumber(valueKey,0)*calibration);
+//		driveLeftTalon.setSetpoint(10000);
+//		driveRightTalon.setSetpoint(10000);
+		driveLeftTalon.set(table.getNumber(valueKey,0)*calibration);
+		driveRightTalon.set(table.getNumber(valueKey,0)*calibration);
+		
+		table.putNumber("calculation", table.getNumber(valueKey,0)*calibration);
 	}
 
 	// Make this return true when this Command no longer needs to run execute()

--- a/src/org/team1540/robot2017/commands/AccurateTurn.java
+++ b/src/org/team1540/robot2017/commands/AccurateTurn.java
@@ -15,6 +15,8 @@ public class AccurateTurn extends Command {
 	public double i = 0.00;
 	public double d = 0.00;
 	
+	private Double lastValue = Double.NaN;
+	
 	private boolean isFinished = false;
 	
 	private NetworkTable table;
@@ -58,12 +60,18 @@ public class AccurateTurn extends Command {
 		table.putNumber("errorL", driveLeftTalon.getError());
 		table.putNumber("errorR", driveRightTalon.getError());
 		
-//		driveLeftTalon.setSetpoint(10000);
-//		driveRightTalon.setSetpoint(10000);
-		driveLeftTalon.set(table.getNumber(valueKey,0)*calibration);
-		driveRightTalon.set(table.getNumber(valueKey,0)*calibration);
-		
-		table.putNumber("calculation", table.getNumber(valueKey,0)*calibration);
+		//Note that this code assumes that the value of the degrees to turn will
+		//change every time the camera updates it. While this should be fine in
+		//practice, this may cause unintended side effects if used improperly
+		if (lastValue == Double.NaN || lastValue!=table.getNumber(valueKey,0)) {
+			lastValue = table.getNumber(valueKey,0);
+			driveLeftTalon.set(
+					(table.getNumber(valueKey,0)-driveLeftTalon.getPosition())
+					*calibration);
+			driveRightTalon.set(
+					(table.getNumber(valueKey,0)-driveRightTalon.getPosition())
+					*calibration);
+		}
 	}
 
 	// Make this return true when this Command no longer needs to run execute()

--- a/src/org/team1540/robot2017/commands/AccurateTurn.java
+++ b/src/org/team1540/robot2017/commands/AccurateTurn.java
@@ -10,7 +10,10 @@ import edu.wpi.first.wpilibj.networktables.NetworkTable;
 public class AccurateTurn extends Command {
 
 	//TODO make these tunable
-	public double calibration = 1;
+	//(1/360)*(24pi)*(1/(4pi))*125*15
+	//degrees to turn = (1/360)*(turning circumference)*(1/wheel circumference) *
+	//(encoders ticks per wheel turn)
+	public double calibration = 31.25;
 	public double p = 0.10;
 	public double i = 0.00;
 	public double d = 0.00;
@@ -59,6 +62,7 @@ public class AccurateTurn extends Command {
 		table.putNumber("positionR", driveRightTalon.getEncPosition());
 		table.putNumber("errorL", driveLeftTalon.getError());
 		table.putNumber("errorR", driveRightTalon.getError());
+		table.putBoolean("lastValue!=number", lastValue!=table.getNumber(valueKey,0));			
 		
 		//Note that this code assumes that the value of the degrees to turn will
 		//change every time the camera updates it. While this should be fine in
@@ -66,11 +70,15 @@ public class AccurateTurn extends Command {
 		if (lastValue == Double.NaN || lastValue!=table.getNumber(valueKey,0)) {
 			lastValue = table.getNumber(valueKey,0);
 			driveLeftTalon.set(
-					(table.getNumber(valueKey,0)-driveLeftTalon.getPosition())
-					*calibration);
+					(table.getNumber(valueKey,0))*calibration+
+					driveLeftTalon.getPosition());
 			driveRightTalon.set(
-					(table.getNumber(valueKey,0)-driveRightTalon.getPosition())
-					*calibration);
+					(-table.getNumber(valueKey,0))*calibration+
+					driveRightTalon.getPosition());
+			table.putNumber("calculationL",(table.getNumber(valueKey,0))*calibration+
+					driveLeftTalon.getPosition());
+			table.putNumber("calculationR",(-table.getNumber(valueKey,0))*calibration+
+					driveRightTalon.getPosition());
 		}
 	}
 

--- a/src/org/team1540/robot2017/commands/AccurateTurn.java
+++ b/src/org/team1540/robot2017/commands/AccurateTurn.java
@@ -1,0 +1,92 @@
+package org.team1540.robot2017.commands;
+
+import org.team1540.robot2017.Robot;
+
+import com.ctre.CANTalon;
+
+import edu.wpi.first.wpilibj.command.Command;
+import edu.wpi.first.wpilibj.networktables.NetworkTable;
+
+public class AccurateTurn extends Command {
+
+	//TODO make these tunable
+	public double calibration = 1;
+	public double p = 0.0;
+	public double i = 0.0;
+	public double d = 0.0;
+	
+	private boolean isFinished = false;
+	
+	public String address = "";
+	private NetworkTable table;
+	private String valueKey;
+	
+	private CANTalon driveLeftTalon = Robot.driveTrain.driveLeftTalon;
+	private CANTalon driveRightTalon = Robot.driveTrain.driveLeftTalon;
+	
+	public AccurateTurn(String tableKey, String valueKey) {
+		NetworkTable.setIPAddress(address);
+		NetworkTable.setClientMode();
+		table = NetworkTable.getTable(tableKey);
+		this.valueKey = valueKey;
+	}
+	
+	public AccurateTurn(String tableKey, String valueKey, String address) {
+		this.address = address;
+		NetworkTable.setIPAddress(address);
+		NetworkTable.setClientMode();
+		table = NetworkTable.getTable(tableKey);
+		this.valueKey = valueKey;
+	}
+	
+	// Called just before this Command runs the first time
+	@Override
+	protected void initialize() {
+		Robot.driveTrain.setControlModeAsFollower();
+	}
+
+	// Called repeatedly when this Command is scheduled to run
+	@Override
+	protected void execute() {
+		driveLeftTalon.setP(p);
+		driveLeftTalon.setI(i);
+		driveLeftTalon.setD(d);
+		driveRightTalon.setP(p);
+		driveRightTalon.setI(i);
+		driveRightTalon.setD(d);
+		
+		driveLeftTalon.setSetpoint(table.getNumber(valueKey,0)*calibration);
+		driveLeftTalon.setSetpoint(-table.getNumber(valueKey,0)*calibration);
+	}
+
+	// Make this return true when this Command no longer needs to run execute()
+	@Override
+	protected boolean isFinished() {
+		return isFinished;
+	}
+
+	// Called once after isFinished returns true
+	@Override
+	protected void end() {
+		Robot.driveTrain.setControlModeAsCurrent();
+		Robot.driveTrain.setAll(0);
+	}
+
+	// Called when another command which requires one or more of the same
+	// subsystems is scheduled to run
+	@Override
+	protected void interrupted() {
+		end();
+	}
+	
+	/**
+	 * Sets if the auto is finished.
+	 * @param toSet If auto is finished
+	 * @return Previous value
+	 */
+	public boolean setIsFinished(boolean toSet) {
+		boolean wasFinished = isFinished;
+		isFinished = toSet;
+		return wasFinished;
+	}
+}

--- a/src/org/team1540/robot2017/commands/AccurateTurn.java
+++ b/src/org/team1540/robot2017/commands/AccurateTurn.java
@@ -21,7 +21,7 @@ public class AccurateTurn extends Command {
 	private String valueKey;
 	
 	private CANTalon driveLeftTalon = Robot.driveTrain.driveLeftTalon;
-	private CANTalon driveRightTalon = Robot.driveTrain.driveLeftTalon;
+	private CANTalon driveRightTalon = Robot.driveTrain.driveRightTalon;
 	
 	public AccurateTurn(String tableKey, String valueKey) {
 		table = NetworkTable.getTable(tableKey);

--- a/src/org/team1540/robot2017/subsystems/DriveTrain.java
+++ b/src/org/team1540/robot2017/subsystems/DriveTrain.java
@@ -9,40 +9,98 @@ import com.ctre.CANTalon.TalonControlMode;
 import edu.wpi.first.wpilibj.command.Subsystem;
 
 public class DriveTrain extends Subsystem {
-
-    private final CANTalon driveRightTalon = new CANTalon(RobotMap.driveTalonRightA);
-    private final CANTalon driveRightBTalon = new CANTalon(RobotMap.driveTalonRightB);
-    private final CANTalon driveRightCTalon = new CANTalon(RobotMap.driveTalonRightC);
-    private final CANTalon driveLeftTalon = new CANTalon(RobotMap.driveTalonLeftA);
-    private final CANTalon driveLeftBTalon = new CANTalon(RobotMap.driveTalonLeftB);
-    private final CANTalon driveLeftCTalon = new CANTalon(RobotMap.driveTalonLeftC);
-    private final CANTalon[] talons = { driveRightTalon, driveRightBTalon, driveRightCTalon, driveLeftTalon, driveLeftBTalon, driveLeftCTalon };
-
-    public DriveTrain() {
-        for (CANTalon talon : talons) {
-            talon.setVoltageRampRate(0.1);
-            talon.enableBrakeMode(true);
-        }
+	
+	public final CANTalon driveRightTalon = new CANTalon(RobotMap.driveTalonRightA);
+	public final CANTalon driveRightBTalon = new CANTalon(RobotMap.driveTalonRightB);
+	public final CANTalon driveRightCTalon = new CANTalon(RobotMap.driveTalonRightC);
+	public final CANTalon driveLeftTalon = new CANTalon(RobotMap.driveTalonLeftA);
+	public final CANTalon driveLeftBTalon = new CANTalon(RobotMap.driveTalonLeftB);
+	public final CANTalon driveLeftCTalon = new CANTalon(RobotMap.driveTalonLeftC);
+	
+	public DriveTrain() {
+		driveRightTalon.changeControlMode(TalonControlMode.PercentVbus);
+		driveRightBTalon.changeControlMode(TalonControlMode.Follower);
+		driveRightCTalon.changeControlMode(TalonControlMode.Follower);
+//		driveRightTalon.reverseOutput(true);
+		driveLeftTalon.changeControlMode(TalonControlMode.PercentVbus);
+		driveLeftBTalon.changeControlMode(TalonControlMode.Follower);
+		driveLeftCTalon.changeControlMode(TalonControlMode.Follower);
+		driveRightBTalon.set(driveRightTalon.getDeviceID());
+		driveRightCTalon.set(driveRightTalon.getDeviceID());
+		driveLeftBTalon.set(driveLeftTalon.getDeviceID());
+		driveLeftCTalon.set(driveLeftTalon.getDeviceID());
+		
+        driveRightTalon.configNominalOutputVoltage(+0f, -0f);
+        driveRightTalon.configPeakOutputVoltage(+12f, -12f);
+        driveRightTalon.setAllowableClosedLoopErr(0);
+        driveRightTalon.setProfile(0);
+        driveRightTalon.ClearIaccum();
         
-        driveRightTalon.changeControlMode(TalonControlMode.PercentVbus);
-        driveRightBTalon.changeControlMode(TalonControlMode.Follower);
-        driveRightCTalon.changeControlMode(TalonControlMode.Follower);
-        driveLeftTalon.changeControlMode(TalonControlMode.PercentVbus);
-        driveLeftBTalon.changeControlMode(TalonControlMode.Follower);
-        driveLeftCTalon.changeControlMode(TalonControlMode.Follower);
-        driveRightBTalon.set(driveRightTalon.getDeviceID());
-        driveRightCTalon.set(driveRightTalon.getDeviceID());
-        driveLeftBTalon.set(driveLeftTalon.getDeviceID());
-        driveLeftCTalon.set(driveLeftTalon.getDeviceID());
-    }
-
-    @Override
-    protected void initDefaultCommand() {
-        setDefaultCommand(new IdleDrive());
-    }
-
-    public void tankDrive(double left, double right) {
-        driveRightTalon.set(right);
-        driveLeftTalon.set(left);
-    }
+        driveLeftTalon.configNominalOutputVoltage(+0f, -0f);
+        driveLeftTalon.configPeakOutputVoltage(+12f, -12f);
+        driveLeftTalon.setAllowableClosedLoopErr(0);
+        driveLeftTalon.setProfile(0);
+        driveLeftTalon.ClearIaccum();
+	}
+	
+	@Override
+	protected void initDefaultCommand() {
+		setDefaultCommand(new IdleDrive());
+	}
+	
+	public void setAll(double output) {
+		driveRightTalon.set(output);
+		driveRightBTalon.set(output);
+		driveRightCTalon.set(output);
+		driveLeftTalon.set(output);
+		driveLeftBTalon.set(output);
+		driveLeftCTalon.set(output);
+	}
+	
+	public void setRight(double output) {
+		driveRightTalon.set(output);
+		driveRightBTalon.set(output);
+		driveRightCTalon.set(output);
+	}
+	
+	public void setLeft(double output) {
+		driveLeftTalon.set(output);
+		driveLeftBTalon.set(output);
+		driveLeftCTalon.set(output);
+	}
+	
+	/**
+	 * Sets all the motors on the left and the right side to be slaves to their respective
+	 * encoder equipped motors.
+	 * This is particularly useful when using PID on the encoder equipped motors.
+	 */
+	public void setControlModeAsFollower() {
+		//hard coding is stupid but Amber told me to do it
+		driveRightBTalon.changeControlMode(CANTalon.TalonControlMode.Follower);
+		driveRightCTalon.changeControlMode(CANTalon.TalonControlMode.Follower);
+		driveLeftBTalon.changeControlMode(CANTalon.TalonControlMode.Follower);
+		driveLeftCTalon.changeControlMode(CANTalon.TalonControlMode.Follower);
+		driveRightBTalon.set(driveRightTalon.getDeviceID());
+		driveRightCTalon.set(driveRightTalon.getDeviceID());
+		driveLeftBTalon.set(driveLeftTalon.getDeviceID());
+		driveLeftCTalon.set(driveLeftTalon.getDeviceID());
+	}
+	
+	/**
+	 * Sets all the motors to use current as the control method.
+	 */
+	public void setControlModeAsCurrent() {
+		//hard coding is stupid but Amber told me to do it
+		driveRightTalon.changeControlMode(CANTalon.TalonControlMode.Current);
+		driveRightBTalon.changeControlMode(CANTalon.TalonControlMode.Current);
+		driveRightCTalon.changeControlMode(CANTalon.TalonControlMode.Current);
+		driveLeftTalon.changeControlMode(CANTalon.TalonControlMode.Current);
+		driveLeftBTalon.changeControlMode(CANTalon.TalonControlMode.Current);
+		driveLeftCTalon.changeControlMode(CANTalon.TalonControlMode.Current);
+	}
+	
+	public void tankDrive(double left, double right) {
+		driveRightTalon.set(right);
+		driveLeftTalon.set(left);
+	}
 }

--- a/src/org/team1540/robot2017/subsystems/DriveTrain.java
+++ b/src/org/team1540/robot2017/subsystems/DriveTrain.java
@@ -1,7 +1,6 @@
 package org.team1540.robot2017.subsystems;
 
 import org.team1540.robot2017.RobotMap;
-import org.team1540.robot2017.commands.IdleDrive;
 
 import com.ctre.CANTalon;
 import com.ctre.CANTalon.TalonControlMode;
@@ -45,7 +44,7 @@ public class DriveTrain extends Subsystem {
 	
 	@Override
 	protected void initDefaultCommand() {
-		setDefaultCommand(new IdleDrive());
+		//setDefaultCommand(new IdleDrive());
 	}
 	
 	public void setAll(double output) {
@@ -71,19 +70,22 @@ public class DriveTrain extends Subsystem {
 	
 	/**
 	 * Sets all the motors on the left and the right side to be slaves to their respective
-	 * encoder equipped motors.
+	 * encoder equipped motors. Sets the left and right talon to use position as the 
+	 * control mode.
 	 * This is particularly useful when using PID on the encoder equipped motors.
 	 */
 	public void setControlModeAsFollower() {
 		//hard coding is stupid but Amber told me to do it
+		driveRightTalon.changeControlMode(CANTalon.TalonControlMode.Position);
+		driveLeftTalon.changeControlMode(CANTalon.TalonControlMode.Position);
 		driveRightBTalon.changeControlMode(CANTalon.TalonControlMode.Follower);
 		driveRightCTalon.changeControlMode(CANTalon.TalonControlMode.Follower);
 		driveLeftBTalon.changeControlMode(CANTalon.TalonControlMode.Follower);
 		driveLeftCTalon.changeControlMode(CANTalon.TalonControlMode.Follower);
-		driveRightBTalon.set(driveRightTalon.getDeviceID());
-		driveRightCTalon.set(driveRightTalon.getDeviceID());
-		driveLeftBTalon.set(driveLeftTalon.getDeviceID());
-		driveLeftCTalon.set(driveLeftTalon.getDeviceID());
+//		driveRightBTalon.set(driveRightTalon.getDeviceID());
+//		driveRightCTalon.set(driveRightTalon.getDeviceID());
+//		driveLeftBTalon.set(driveLeftTalon.getDeviceID());
+//		driveLeftCTalon.set(driveLeftTalon.getDeviceID());
 	}
 	
 	/**


### PR DESCRIPTION
This contains code for turning accurate distances given a NetworkTable with a set value, though this could be easily abstracted/allowed to take a set value using a method. There were issues with it not working properly with the Robot.java in the version of `master` this originally branched from due to some conflict with another command being called and setting the setpoint to zero, but this doesn't appear to be an issue with AccurateTurn itself, as once the other commands were removed the AccurateTurn worked fine.

There are changes to RobotMap included so the motors are actually correctly bound, but it might be a good idea to make some changes manually, as there appear to be conflicts with the current RobotMap in master.

DriveTrain had additional convenience methods added.